### PR TITLE
 Idefics_FT.ipynb: Include eos tokens in collated finetuning data

### DIFF
--- a/Idefics_FT.ipynb
+++ b/Idefics_FT.ipynb
@@ -423,7 +423,7 @@
     "              ]\n",
     "          }\n",
     "      ]\n",
-    "      text = processor.apply_chat_template(messages, add_generation_prompt=False)\n",
+    "      text = processor.apply_chat_template(messages, add_generation_prompt=False) + processor.tokenizer.eos_token\n",
     "      texts.append(text.strip())\n",
     "      images.append([image])\n",
     "\n",


### PR DESCRIPTION
When I try inferring with the old version of the Idefics finetuning notebook ([here](https://github.com/merveenoyan/smol-vision/blob/6cc186b903c9ca69dd4c74920f655bc85457cdb0/Idefics_FT.ipynb)), the generated text doesn't ever stop, and the model outputs repetitions and garbage apparently forever. To me, this seems to be because no EOS tokens are added to the finetuning data, and I changed the code accordingly (with the change, my notebook seems to work for me).

The current version of the finetuning notebook doesn't work on my machine anyway in this form for apparently several reasons (and doesn't contain inference code), so I **couldn't** check if it will work with this patch. But it seemed to me that a patch similar to this one is necessary.

I am still not sure whether this output format proposed is correct. In the version I propose (formatting+adding endoftext), the string ends with `...textextext<end_of_utterance>\n<|end_of_text|>`, i.e. contains <end_of_utterance> and a newline as well. @merveenoyan is this the intended formatting?
